### PR TITLE
validate page number - resolves #11

### DIFF
--- a/www/submitRequest.php
+++ b/www/submitRequest.php
@@ -23,7 +23,17 @@
     $aAuthor = $_POST["aAuthor"];
     $start = $_POST["start"];
     $end = $_POST["end"];
+    $comment = '';
     $regionalURL = $_POST["regionalURL"];
+
+    // Page number validation
+    if ($start == 0 AND $end == 0) {
+        $comment = 'Page range is unknown';
+        $start = 1; $end = 1;
+    } else if ($start == 0 OR $end == 0 OR $start > $end) {
+        $comment = "Original request had invalid page range: $start - $end";
+        $start = 1; $end = 1;
+    }
 
     $emptyResponse = array (
         "request_id" => '',
@@ -54,6 +64,7 @@
                 'to_page' => $end,
             ),
         ),
+        'comment' => $comment,
         'copyrights_declaration_signed_by_patron' => true,
     );
     $requestJSON = json_encode($requestArray);


### PR DESCRIPTION
If a page number equals 0 or start page is greater than end page, change page numbers to 1 - 1 and add a comment with the original invalid range.

If both the start and end page numbers are zero, change page numbers to 1 - 1 and add a comment indicating that the page range is unknown.