### PR TITLE
Handle App Service warm-up traffic and harden Digitization Addon request validation

### DIFF
--- a/www/healthz.php
+++ b/www/healthz.php
@@ -1,0 +1,4 @@
+<?php
+http_response_code(200);
+header('Content-Type: text/plain; charset=utf-8');
+echo "ok\n";

--- a/www/index.php
+++ b/www/index.php
@@ -1,43 +1,63 @@
 <?php
-	require_once 'utils/config.php';
-// Azure update
-    if (isset($_GET["illiadCS"])) {
-        if (ILLIAD_CLIENT_SECRET != $_GET["illiadCS"]) {
-            http_response_code(403);
-            exit;
-        }
-    } else {
+    require_once 'utils/config.php';
+
+    $illiadCS = $_GET["illiadCS"] ?? null;
+    $instCode = $_GET["instCode"] ?? null;
+    $usrId    = $_GET["usrId"] ?? null;
+
+    // Allow Azure warm-up probes / root hits without generating noisy 400s
+    if ($illiadCS === null && $instCode === null && $usrId === null) {
+        http_response_code(200);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "Alma Digitization Addon endpoint is online.\n";
+        exit;
+    }
+
+    if ($illiadCS === null) {
+        error_log("ADDON REJECT: missing illiadCS on " . ($_SERVER['REQUEST_URI'] ?? ''));
         http_response_code(400);
         exit;
     }
 
-    if (isset($_GET["instCode"])) {
-        $instCode = $_GET["instCode"];
-        $instName = $izSettings[$instCode]['name'];
-    } else {
+    if (ILLIAD_CLIENT_SECRET != $illiadCS) {
+        error_log("ADDON REJECT: invalid illiadCS on " . ($_SERVER['REQUEST_URI'] ?? ''));
+        http_response_code(403);
+        exit;
+    }
+
+    if ($instCode === null) {
+        error_log("ADDON REJECT: missing instCode on " . ($_SERVER['REQUEST_URI'] ?? ''));
         http_response_code(400);
         exit;
     }
 
-    if (isset($_GET["usrId"])) {
-        $usrId = $_GET["usrId"];
-    } else {
+    if (!isset($izSettings[$instCode])) {
+        error_log("ADDON REJECT: invalid instCode '$instCode'");
         http_response_code(400);
         exit;
     }
+
+    $instName = $izSettings[$instCode]['name'];
+
+    if ($usrId === null) {
+        error_log("ADDON REJECT: missing usrId on " . ($_SERVER['REQUEST_URI'] ?? ''));
+        http_response_code(400);
+        exit;
+    }
+
     if (isset($_GET["tn"])) {
         $tn = $_GET["tn"];
     } else {
         $tn = '';
     }
+
     if (isset($_GET["itemId"])) {
-        // Strips accidental non-numeric characters from itemId
         $itemId = preg_replace("/[^0-9]/", "", $_GET["itemId"]);
     } else {
         $itemId = '';
     }
+
     if (isset($_GET["mmsId"])) {
-        // Strips accidental non-numeric characters from mmsId
         $mmsId = preg_replace("/[^0-9]/", "", $_GET["mmsId"]);
     } else {
         $mmsId = '';
@@ -48,6 +68,7 @@
     } else {
         $aTitle = '';
     }
+
     if (isset($_GET["aAuthor"])) {
         $aAuthor = $_GET["aAuthor"];
     } else {
@@ -55,7 +76,6 @@
     }
 
     if (isset($_GET["pageRange"])) {
-        //TODO: Implement Validation for Page Range Splitting
         $pageRange = $_GET["pageRange"];
     } else {
         $pageRange = '';

--- a/www/submitRequest.php
+++ b/www/submitRequest.php
@@ -2,33 +2,69 @@
     require_once 'utils/config.php';
     require_once 'utils/jsonapi.php';
 
+    if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+        http_response_code(405);
+        header('Allow: POST');
+        exit;
+    }
+
     // check shared secret credential
-    if (isset($_POST["illiadCS"])) {
-        if (ILLIAD_CLIENT_SECRET != $_POST["illiadCS"]) {
-            http_response_code(403);
-            exit;
-        }
-    } else {
+    $illiadCS = $_POST["illiadCS"] ?? null;
+    if ($illiadCS === null) {
+        error_log("ADDON REJECT: missing illiadCS on submit");
         http_response_code(400);
         exit;
     }
 
+    if (ILLIAD_CLIENT_SECRET != $illiadCS) {
+        error_log("ADDON REJECT: invalid illiadCS on submit");
+        http_response_code(403);
+        exit;
+    }
+
     // Loads variables from form
-    $instCode = $_POST["instCode"];
+    $instCode = $_POST["instCode"] ?? null;
+    if ($instCode === null || !isset($izSettings[$instCode])) {
+        error_log("ADDON REJECT: invalid or missing instCode on submit");
+        http_response_code(400);
+        exit;
+    }
+
     $apiKey = $izSettings[$instCode]['apikey'];
-    $usrId = $_POST["usrId"];
-    $itemId = preg_replace("/[^0-9]/", "", $_POST["itemId"]); // Strips accidental non-numeric characters from itemId
-    $mmsId = preg_replace("/[^0-9]/", "", $_POST["mmsId"]); // Strips accidental non-numeric characters from mmsId
-    $aTitle = $_POST["aTitle"];
-    $aAuthor = $_POST["aAuthor"];
-    $start = $_POST["start"];
-    $end = $_POST["end"];
-    $tn = $_POST["tn"];
+
+    $usrId = $_POST["usrId"] ?? null;
+    if ($usrId === null || $usrId === '') {
+        error_log("ADDON REJECT: missing usrId on submit");
+        http_response_code(400);
+        exit;
+    }
+
+    $itemId = preg_replace("/[^0-9]/", "", $_POST["itemId"] ?? "");
+    $mmsId = preg_replace("/[^0-9]/", "", $_POST["mmsId"] ?? "");
+    $aTitle = $_POST["aTitle"] ?? '';
+    $aAuthor = $_POST["aAuthor"] ?? '';
+    $start = $_POST["start"] ?? '';
+    $end = $_POST["end"] ?? '';
+    $tn = $_POST["tn"] ?? '';
+
+    if ($itemId === '' || $mmsId === '') {
+        error_log("ADDON REJECT: missing itemId or mmsId on submit");
+        http_response_code(400);
+        exit;
+    }
+
+    if ($start === '' || $end === '') {
+        error_log("ADDON REJECT: missing start or end page on submit");
+        http_response_code(400);
+        exit;
+    }
+
     if ($tn == '') {
         $tn = 'unknown';
     }
     $comment = "ILLiad TN: $tn; ";
-    $regionalURL = $_POST["regionalURL"];
+
+    $regionalURL = $_POST["regionalURL"] ?? $apiSettings["defaultURL"];
 
     // Page number validation
     if ($start == 0 AND $end == 0) {

--- a/www/utils/jsonapi.php
+++ b/www/utils/jsonapi.php
@@ -33,17 +33,18 @@ function sendCurlRequest( $ch, $postfields=NULL ) {
     }
 
     $response = curl_exec( $ch );
-    list ($hdr, $body) = explode( "\r\n\r\n", $response, 2 );
 
     # set the HTTP response code based on cURL error or API response code
     $errno = curl_errno( $ch );
     if ($errno) {
         $code = 500;
         $message = curl_error( $ch ) . " ($errno)";
-        error_log( "cURL Error:  $message" );
+        error_log( "cURL Error: $message" );
         $body = '{"status":500,"error":"'. $message . '"}';
     } else {
         $code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+        $headerSize = curl_getinfo( $ch, CURLINFO_HEADER_SIZE );
+        $body = substr( $response, $headerSize );
     }
 
     return array ($code, $body);


### PR DESCRIPTION
This PR fixes noisy 400 responses likely caused by Azure App Service warm-up or root-path probes.

Changes:
- add www/healthz.php for a clean warm-up endpoint
- make index.php return 200 for plain root hits
- add defensive request validation in submitRequest.php
- make cURL response body parsing more robust in jsonapi.php

After merge, set:
WEBSITE_WARMUP_PATH=/healthz.php